### PR TITLE
From Earl: Update watut-common.toml

### DIFF
--- a/config/watut-common.toml
+++ b/config/watut-common.toml
@@ -2,7 +2,7 @@
 #General mod settings
 [general]
 	#-
-	announceIdleStatesInChat = false
+	announceIdleStatesInChat = true
 	#Default 5 minutes
 	#Range: > 0
 	ticksToMarkPlayerIdle = 6000


### PR DESCRIPTION
Implements the AFK message in chat when AFK for longer than 5 minutes. This time can be changed via the `ticksToMarkPlayerIdle` setting located here: https://github.com/katubug/CottageWitch119/edit/main/config/watut-common.toml